### PR TITLE
feat: Allow creating, editing and deleting activities from the UI

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+	"servers": {
+		"github": {
+			"type": "http",
+			"url": "https://api.githubcopilot.com/mcp/"
+		}
+	},
+	"inputs": []
+}

--- a/src/app.py
+++ b/src/app.py
@@ -8,8 +8,15 @@ for extracurricular activities at Mergington High School.
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
 from pathlib import Path
+
+
+class ActivityRequest(BaseModel):
+    description: str
+    schedule: str
+    max_participants: int
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -130,3 +137,40 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+@app.post("/activities")
+def create_activity(activity_name: str, activity: ActivityRequest):
+    """Create a new activity"""
+    if activity_name in activities:
+        raise HTTPException(status_code=400, detail="Activity already exists")
+
+    activities[activity_name] = {
+        "description": activity.description,
+        "schedule": activity.schedule,
+        "max_participants": activity.max_participants,
+        "participants": []
+    }
+    return {"message": f"Activity '{activity_name}' created successfully"}
+
+
+@app.put("/activities/{activity_name}")
+def update_activity(activity_name: str, activity: ActivityRequest):
+    """Update an existing activity's details"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activities[activity_name]["description"] = activity.description
+    activities[activity_name]["schedule"] = activity.schedule
+    activities[activity_name]["max_participants"] = activity.max_participants
+    return {"message": f"Activity '{activity_name}' updated successfully"}
+
+
+@app.delete("/activities/{activity_name}")
+def delete_activity(activity_name: str):
+    """Delete an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    del activities[activity_name]
+    return {"message": f"Activity '{activity_name}' deleted successfully"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Manage activity form elements
+  const manageForm = document.getElementById("manage-form");
+  const manageTitle = document.getElementById("manage-title");
+  const manageMessage = document.getElementById("manage-message");
+  const manageSubmitBtn = document.getElementById("manage-submit-btn");
+  const manageCancelBtn = document.getElementById("manage-cancel-btn");
+  const editModeInput = document.getElementById("edit-mode");
+  const originalNameInput = document.getElementById("original-name");
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -12,6 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -38,7 +48,13 @@ document.addEventListener("DOMContentLoaded", () => {
             : `<p><em>No participants yet</em></p>`;
 
         activityCard.innerHTML = `
-          <h4>${name}</h4>
+          <div class="activity-card-header">
+            <h4>${name}</h4>
+            <div class="activity-actions">
+              <button class="edit-activity-btn btn-icon" data-name="${name}" title="Edit activity">✏️</button>
+              <button class="delete-activity-btn btn-icon btn-danger" data-name="${name}" title="Delete activity">🗑️</button>
+            </div>
+          </div>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
@@ -56,9 +72,19 @@ document.addEventListener("DOMContentLoaded", () => {
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
+      // Add event listeners to participant delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
+      });
+
+      // Add event listeners to activity edit buttons
+      document.querySelectorAll(".edit-activity-btn").forEach((button) => {
+        button.addEventListener("click", handleEditActivity);
+      });
+
+      // Add event listeners to activity delete buttons
+      document.querySelectorAll(".delete-activity-btn").forEach((button) => {
+        button.addEventListener("click", handleDeleteActivity);
       });
     } catch (error) {
       activitiesList.innerHTML =
@@ -110,7 +136,127 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  // Handle form submission
+  // Handle edit activity — populate manage form
+  async function handleEditActivity(event) {
+    const name = event.currentTarget.getAttribute("data-name");
+    const response = await fetch("/activities");
+    const activities = await response.json();
+    const details = activities[name];
+
+    if (!details) return;
+
+    document.getElementById("activity-name").value = name;
+    document.getElementById("activity-description").value = details.description;
+    document.getElementById("activity-schedule").value = details.schedule;
+    document.getElementById("activity-max").value = details.max_participants;
+
+    editModeInput.value = "edit";
+    originalNameInput.value = name;
+    manageTitle.textContent = `Edit Activity: ${name}`;
+    manageSubmitBtn.textContent = "Save Changes";
+    manageCancelBtn.classList.remove("hidden");
+
+    document.getElementById("manage-container").scrollIntoView({ behavior: "smooth" });
+  }
+
+  // Handle delete activity
+  async function handleDeleteActivity(event) {
+    const name = event.currentTarget.getAttribute("data-name");
+
+    if (!confirm(`Are you sure you want to delete "${name}"? This cannot be undone.`)) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/activities/${encodeURIComponent(name)}`, {
+        method: "DELETE",
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showManageMessage(result.message, "success");
+        fetchActivities();
+      } else {
+        showManageMessage(result.detail || "An error occurred", "error");
+      }
+    } catch (error) {
+      showManageMessage("Failed to delete activity. Please try again.", "error");
+      console.error("Error deleting activity:", error);
+    }
+  }
+
+  // Reset manage form to create mode
+  function resetManageForm() {
+    manageForm.reset();
+    editModeInput.value = "create";
+    originalNameInput.value = "";
+    manageTitle.textContent = "Add New Activity";
+    manageSubmitBtn.textContent = "Create Activity";
+    manageCancelBtn.classList.add("hidden");
+    document.getElementById("activity-name").disabled = false;
+  }
+
+  // Show message in manage section
+  function showManageMessage(text, type) {
+    manageMessage.textContent = text;
+    manageMessage.className = type;
+    manageMessage.classList.remove("hidden");
+    setTimeout(() => manageMessage.classList.add("hidden"), 5000);
+  }
+
+  // Cancel edit — go back to create mode
+  manageCancelBtn.addEventListener("click", resetManageForm);
+
+  // Handle manage form submission (create or edit)
+  manageForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const mode = editModeInput.value;
+    const name = document.getElementById("activity-name").value.trim();
+    const body = {
+      description: document.getElementById("activity-description").value.trim(),
+      schedule: document.getElementById("activity-schedule").value.trim(),
+      max_participants: parseInt(document.getElementById("activity-max").value, 10),
+    };
+
+    try {
+      let response;
+
+      if (mode === "create") {
+        response = await fetch(
+          `/activities?activity_name=${encodeURIComponent(name)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+      } else {
+        const original = originalNameInput.value;
+        response = await fetch(`/activities/${encodeURIComponent(original)}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+      }
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showManageMessage(result.message, "success");
+        resetManageForm();
+        fetchActivities();
+      } else {
+        showManageMessage(result.detail || "An error occurred", "error");
+      }
+    } catch (error) {
+      showManageMessage("Request failed. Please try again.", "error");
+      console.error("Error managing activity:", error);
+    }
+  });
+
+  // Handle sign-up form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -39,6 +39,35 @@
         </form>
         <div id="message" class="hidden"></div>
       </section>
+
+      <section id="manage-container">
+        <h3 id="manage-title">Add New Activity</h3>
+        <form id="manage-form">
+          <input type="hidden" id="edit-mode" value="create" />
+          <input type="hidden" id="original-name" value="" />
+          <div class="form-group">
+            <label for="activity-name">Activity Name:</label>
+            <input type="text" id="activity-name" required placeholder="e.g. Robotics Club" />
+          </div>
+          <div class="form-group">
+            <label for="activity-description">Description:</label>
+            <input type="text" id="activity-description" required placeholder="Brief description" />
+          </div>
+          <div class="form-group">
+            <label for="activity-schedule">Schedule:</label>
+            <input type="text" id="activity-schedule" required placeholder="e.g. Mondays, 4:00 PM - 5:30 PM" />
+          </div>
+          <div class="form-group">
+            <label for="activity-max">Max Participants:</label>
+            <input type="number" id="activity-max" required min="1" placeholder="e.g. 20" />
+          </div>
+          <div class="manage-actions">
+            <button type="submit" id="manage-submit-btn">Create Activity</button>
+            <button type="button" id="manage-cancel-btn" class="btn-secondary hidden">Cancel</button>
+          </div>
+        </form>
+        <div id="manage-message" class="hidden"></div>
+      </section>
     </main>
 
     <footer>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -198,3 +198,61 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+/* Activity card header with action buttons */
+.activity-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.activity-card-header h4 {
+  margin-bottom: 0;
+  color: #0066cc;
+}
+
+.activity-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.btn-icon {
+  background: none;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 3px 7px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  color: inherit;
+}
+
+.btn-icon:hover {
+  background-color: #e8eaf6;
+}
+
+.btn-icon.btn-danger:hover {
+  background-color: #ffebee;
+  border-color: #ef9a9a;
+}
+
+/* Secondary button (Cancel) */
+.btn-secondary {
+  background-color: #e0e0e0;
+  color: #333;
+  margin-left: 10px;
+}
+
+.btn-secondary:hover {
+  background-color: #bdbdbd;
+}
+
+/* Manage form actions row */
+.manage-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary

Implements issue #112 — allows administrators to manage activities directly from the web UI without modifying source code.

## Changes

### Backend (`src/app.py`)
- Added `ActivityRequest` Pydantic model for request body validation
- `POST /activities?activity_name=...` — creates a new activity
- `PUT /activities/{activity_name}` — updates description, schedule, and max participants
- `DELETE /activities/{activity_name}` — removes an activity entirely

### Frontend (`src/static/index.html`)
- New **"Add New Activity"** section with a form supporting both create and edit modes
- Fields: name, description, schedule, max participants
- Cancel button (visible only in edit mode)

### JavaScript (`src/static/app.js`)
- Each activity card now has ✏️ Edit and 🗑️ Delete icon buttons
- `handleEditActivity()` — populates the manage form with existing data
- `handleDeleteActivity()` — confirms and calls the DELETE endpoint
- Manage form switches between create/edit mode dynamically

### CSS (`src/static/styles.css`)
- Styles for `.activity-card-header`, `.btn-icon`, `.btn-danger`, `.btn-secondary`, `.manage-actions`

## Testing
1. Start the server: `uvicorn app:app --reload`
2. Open `http://localhost:8000`
3. Use the **Add New Activity** form to create a new activity — it should appear in the list
4. Click ✏️ on any activity — the form should populate with its data
5. Save changes — the card should update
6. Click 🗑️ on any activity — confirm the dialog and it should be removed

Closes #112