### PR TITLE
Add admin activity management CRUD and UI

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,28 @@
+{
+
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "github_token",
+        "description": "GitHub Personal Access Token",
+        "password": true
+      }
+    ],
+    "servers": {
+      "github": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "-e",
+          "GITHUB_PERSONAL_ACCESS_TOKEN",
+          "ghcr.io/github/github-mcp-server"
+        ],
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+        }
+      }
+    }
+  
+}

--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ for extracurricular activities at Mergington High School.
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, Field
 import os
 from pathlib import Path
 
@@ -78,6 +79,35 @@ activities = {
 }
 
 
+class ActivityPayload(BaseModel):
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    schedule: str = Field(min_length=1)
+    max_participants: int = Field(gt=0)
+
+
+def validate_activity_payload(payload: ActivityPayload):
+    cleaned_name = payload.name.strip()
+    cleaned_description = payload.description.strip()
+    cleaned_schedule = payload.schedule.strip()
+
+    if not cleaned_name:
+        raise HTTPException(status_code=400, detail="Activity name is required")
+
+    if not cleaned_description:
+        raise HTTPException(status_code=400, detail="Description is required")
+
+    if not cleaned_schedule:
+        raise HTTPException(status_code=400, detail="Schedule is required")
+
+    return {
+        "name": cleaned_name,
+        "description": cleaned_description,
+        "schedule": cleaned_schedule,
+        "max_participants": payload.max_participants,
+    }
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -86,6 +116,66 @@ def root():
 @app.get("/activities")
 def get_activities():
     return activities
+
+
+@app.post("/activities")
+def create_activity(payload: ActivityPayload):
+    activity_data = validate_activity_payload(payload)
+    activity_name = activity_data["name"]
+
+    if activity_name in activities:
+        raise HTTPException(status_code=400, detail="Activity already exists")
+
+    activities[activity_name] = {
+        "description": activity_data["description"],
+        "schedule": activity_data["schedule"],
+        "max_participants": activity_data["max_participants"],
+        "participants": [],
+    }
+
+    return {"message": f"Created activity {activity_name}"}
+
+
+@app.put("/activities/{activity_name}")
+def update_activity(activity_name: str, payload: ActivityPayload):
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity_data = validate_activity_payload(payload)
+    updated_name = activity_data["name"]
+    existing_activity = activities[activity_name]
+    participant_count = len(existing_activity["participants"])
+
+    if activity_data["max_participants"] < participant_count:
+        raise HTTPException(
+            status_code=400,
+            detail="Max participants cannot be lower than current enrollment",
+        )
+
+    if updated_name != activity_name and updated_name in activities:
+        raise HTTPException(status_code=400, detail="Activity name already exists")
+
+    updated_activity = {
+        "description": activity_data["description"],
+        "schedule": activity_data["schedule"],
+        "max_participants": activity_data["max_participants"],
+        "participants": existing_activity["participants"],
+    }
+
+    if updated_name != activity_name:
+        del activities[activity_name]
+
+    activities[updated_name] = updated_activity
+    return {"message": f"Updated activity {updated_name}"}
+
+
+@app.delete("/activities/{activity_name}")
+def delete_activity(activity_name: str):
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    del activities[activity_name]
+    return {"message": f"Deleted activity {activity_name}"}
 
 
 @app.post("/activities/{activity_name}/signup")
@@ -104,6 +194,9 @@ def signup_for_activity(activity_name: str, email: str):
             status_code=400,
             detail="Student is already signed up"
         )
+
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(status_code=400, detail="Activity is full")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,62 +3,137 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const adminForm = document.getElementById("admin-form");
+  const adminActivitySelect = document.getElementById("admin-activity-select");
+  const adminMessageDiv = document.getElementById("admin-message");
+  const resetAdminFormButton = document.getElementById("reset-admin-form");
+  const adminDeleteButton = document.getElementById("admin-delete-button");
+  const adminSaveButton = document.getElementById("admin-save-button");
+
+  let cachedActivities = {};
+  let editingActivityName = null;
+
+  function showMessage(target, text, type) {
+    target.textContent = text;
+    target.className = type;
+    target.classList.remove("hidden");
+
+    setTimeout(() => {
+      target.classList.add("hidden");
+    }, 5000);
+  }
+
+  function resetAdminForm() {
+    editingActivityName = null;
+    adminForm.reset();
+    adminActivitySelect.value = "";
+    adminSaveButton.textContent = "Create Activity";
+    adminDeleteButton.classList.add("hidden");
+  }
+
+  function populateAdminForm(activityName) {
+    const activity = cachedActivities[activityName];
+
+    if (!activity) {
+      resetAdminForm();
+      return;
+    }
+
+    editingActivityName = activityName;
+    document.getElementById("admin-name").value = activityName;
+    document.getElementById("admin-description").value = activity.description;
+    document.getElementById("admin-schedule").value = activity.schedule;
+    document.getElementById("admin-max-participants").value =
+      activity.max_participants;
+    adminActivitySelect.value = activityName;
+    adminSaveButton.textContent = "Update Activity";
+    adminDeleteButton.classList.remove("hidden");
+  }
+
+  function createActivityCard(name, details) {
+    const activityCard = document.createElement("div");
+    activityCard.className = "activity-card";
+
+    const spotsLeft = details.max_participants - details.participants.length;
+
+    const participantsHTML =
+      details.participants.length > 0
+        ? `<div class="participants-section">
+            <h5>Participants:</h5>
+            <ul class="participants-list">
+              ${details.participants
+                .map(
+                  (email) =>
+                    `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">Remove</button></li>`
+                )
+                .join("")}
+            </ul>
+          </div>`
+        : `<p><em>No participants yet</em></p>`;
+
+    activityCard.innerHTML = `
+      <div class="card-header">
+        <h4>${name}</h4>
+        <button type="button" class="edit-btn" data-activity="${name}">Edit</button>
+      </div>
+      <p>${details.description}</p>
+      <p><strong>Schedule:</strong> ${details.schedule}</p>
+      <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+      <div class="participants-container">
+        ${participantsHTML}
+      </div>
+    `;
+
+    return activityCard;
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
       const response = await fetch("/activities");
       const activities = await response.json();
+      cachedActivities = activities;
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
+      adminActivitySelect.innerHTML =
+        '<option value="">-- Create a new activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
-        const activityCard = document.createElement("div");
-        activityCard.className = "activity-card";
-
-        const spotsLeft =
-          details.max_participants - details.participants.length;
-
-        // Create participants HTML with delete icons instead of bullet points
-        const participantsHTML =
-          details.participants.length > 0
-            ? `<div class="participants-section">
-              <h5>Participants:</h5>
-              <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
-            : `<p><em>No participants yet</em></p>`;
-
-        activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-          <div class="participants-container">
-            ${participantsHTML}
-          </div>
-        `;
-
+        const activityCard = createActivityCard(name, details);
         activitiesList.appendChild(activityCard);
 
-        // Add option to select dropdown
         const option = document.createElement("option");
         option.value = name;
         option.textContent = name;
         activitySelect.appendChild(option);
+
+        const adminOption = document.createElement("option");
+        adminOption.value = name;
+        adminOption.textContent = name;
+        adminActivitySelect.appendChild(adminOption);
       });
 
-      // Add event listeners to delete buttons
+      if (editingActivityName && cachedActivities[editingActivityName]) {
+        populateAdminForm(editingActivityName);
+      } else if (editingActivityName) {
+        resetAdminForm();
+      }
+
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
+      });
+
+      document.querySelectorAll(".edit-btn").forEach((button) => {
+        button.addEventListener("click", () => {
+          populateAdminForm(button.getAttribute("data-activity"));
+          document
+            .getElementById("admin-container")
+            .scrollIntoView({ behavior: "smooth", block: "start" });
+        });
       });
     } catch (error) {
       activitiesList.innerHTML =
@@ -86,26 +161,13 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
-        fetchActivities();
+        showMessage(messageDiv, result.message, "success");
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(messageDiv, result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage(messageDiv, "Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -130,31 +192,117 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(messageDiv, result.message, "success");
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
-        fetchActivities();
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(messageDiv, result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage(messageDiv, "Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
+    }
+  });
+
+  adminActivitySelect.addEventListener("change", (event) => {
+    const selectedActivity = event.target.value;
+
+    if (!selectedActivity) {
+      resetAdminForm();
+      return;
+    }
+
+    populateAdminForm(selectedActivity);
+  });
+
+  resetAdminFormButton.addEventListener("click", () => {
+    resetAdminForm();
+  });
+
+  adminDeleteButton.addEventListener("click", async () => {
+    if (!editingActivityName) {
+      showMessage(adminMessageDiv, "Select an activity to delete.", "error");
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(editingActivityName)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(adminMessageDiv, result.message, "success");
+        resetAdminForm();
+        await fetchActivities();
+      } else {
+        showMessage(
+          adminMessageDiv,
+          result.detail || "Unable to delete activity.",
+          "error"
+        );
+      }
+    } catch (error) {
+      showMessage(adminMessageDiv, "Failed to delete activity.", "error");
+      console.error("Error deleting activity:", error);
+    }
+  });
+
+  adminForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const payload = {
+      name: document.getElementById("admin-name").value,
+      description: document.getElementById("admin-description").value,
+      schedule: document.getElementById("admin-schedule").value,
+      max_participants: Number(
+        document.getElementById("admin-max-participants").value
+      ),
+    };
+
+    const isEditing = Boolean(editingActivityName);
+    const endpoint = isEditing
+      ? `/activities/${encodeURIComponent(editingActivityName)}`
+      : "/activities";
+    const method = isEditing ? "PUT" : "POST";
+
+    try {
+      const response = await fetch(endpoint, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(adminMessageDiv, result.message, "success");
+        editingActivityName = payload.name.trim();
+        await fetchActivities();
+
+        if (!isEditing) {
+          populateAdminForm(payload.name.trim());
+        }
+      } else {
+        showMessage(
+          adminMessageDiv,
+          result.detail || "Unable to save activity.",
+          "error"
+        );
+      }
+    } catch (error) {
+      showMessage(adminMessageDiv, "Failed to save activity.", "error");
+      console.error("Error saving activity:", error);
     }
   });
 
   // Initialize app
   fetchActivities();
+  resetAdminForm();
 });

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -56,33 +56,90 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const spotsLeft = details.max_participants - details.participants.length;
 
-    const participantsHTML =
-      details.participants.length > 0
-        ? `<div class="participants-section">
-            <h5>Participants:</h5>
-            <ul class="participants-list">
-              ${details.participants
-                .map(
-                  (email) =>
-                    `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">Remove</button></li>`
-                )
-                .join("")}
-            </ul>
-          </div>`
-        : `<p><em>No participants yet</em></p>`;
+    // Card header
+    const headerDiv = document.createElement("div");
+    headerDiv.className = "card-header";
 
-    activityCard.innerHTML = `
-      <div class="card-header">
-        <h4>${name}</h4>
-        <button type="button" class="edit-btn" data-activity="${name}">Edit</button>
-      </div>
-      <p>${details.description}</p>
-      <p><strong>Schedule:</strong> ${details.schedule}</p>
-      <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-      <div class="participants-container">
-        ${participantsHTML}
-      </div>
-    `;
+    const titleEl = document.createElement("h4");
+    titleEl.textContent = name;
+    headerDiv.appendChild(titleEl);
+
+    const editButton = document.createElement("button");
+    editButton.type = "button";
+    editButton.className = "edit-btn";
+    editButton.textContent = "Edit";
+    editButton.dataset.activity = name;
+    headerDiv.appendChild(editButton);
+
+    activityCard.appendChild(headerDiv);
+
+    // Description
+    const descriptionP = document.createElement("p");
+    descriptionP.textContent = details.description;
+    activityCard.appendChild(descriptionP);
+
+    // Schedule
+    const scheduleP = document.createElement("p");
+    const scheduleStrong = document.createElement("strong");
+    scheduleStrong.textContent = "Schedule:";
+    scheduleP.appendChild(scheduleStrong);
+    scheduleP.appendChild(document.createTextNode(" " + details.schedule));
+    activityCard.appendChild(scheduleP);
+
+    // Availability
+    const availabilityP = document.createElement("p");
+    const availabilityStrong = document.createElement("strong");
+    availabilityStrong.textContent = "Availability:";
+    availabilityP.appendChild(availabilityStrong);
+    availabilityP.appendChild(
+      document.createTextNode(" " + spotsLeft + " spots left")
+    );
+    activityCard.appendChild(availabilityP);
+
+   // Participants container
+    const participantsContainer = document.createElement("div");
+    participantsContainer.className = "participants-container";
+
+    if (details.participants.length > 0) {
+      const participantsSection = document.createElement("div");
+      participantsSection.className = "participants-section";
+
+      const participantsHeader = document.createElement("h5");
+      participantsHeader.textContent = "Participants:";
+      participantsSection.appendChild(participantsHeader);
+
+      const participantsList = document.createElement("ul");
+      participantsList.className = "participants-list";
+
+      details.participants.forEach((email) => {
+        const li = document.createElement("li");
+
+        const emailSpan = document.createElement("span");
+        emailSpan.className = "participant-email";
+        emailSpan.textContent = email;
+        li.appendChild(emailSpan);
+
+        const deleteButton = document.createElement("button");
+        deleteButton.className = "delete-btn";
+        deleteButton.textContent = "Remove";
+        deleteButton.dataset.activity = name;
+        deleteButton.dataset.email = email;
+        li.appendChild(deleteButton);
+
+        participantsList.appendChild(li);
+      });
+
+      participantsSection.appendChild(participantsList);
+      participantsContainer.appendChild(participantsSection);
+    } else {
+      const noParticipantsP = document.createElement("p");
+      const em = document.createElement("em");
+      em.textContent = "No participants yet";
+      noParticipantsP.appendChild(em);
+      participantsContainer.appendChild(noParticipantsP);
+    }
+
+    activityCard.appendChild(participantsContainer);
 
     return activityCard;
   }

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -39,6 +39,47 @@
         </form>
         <div id="message" class="hidden"></div>
       </section>
+
+      <section id="admin-container">
+        <h3>Manage Activities</h3>
+        <p class="section-intro">
+          Create a new activity or select an existing one to edit or delete it.
+        </p>
+
+        <div class="admin-toolbar">
+          <div class="form-group">
+            <label for="admin-activity-select">Edit Existing Activity:</label>
+            <select id="admin-activity-select">
+              <option value="">-- Create a new activity --</option>
+            </select>
+          </div>
+          <button type="button" id="reset-admin-form">Create New</button>
+        </div>
+
+        <form id="admin-form">
+          <div class="form-group">
+            <label for="admin-name">Activity Name:</label>
+            <input type="text" id="admin-name" required placeholder="Robotics Club" />
+          </div>
+          <div class="form-group">
+            <label for="admin-description">Description:</label>
+            <textarea id="admin-description" required placeholder="Build robots and compete in regional events"></textarea>
+          </div>
+          <div class="form-group">
+            <label for="admin-schedule">Schedule:</label>
+            <input type="text" id="admin-schedule" required placeholder="Mondays and Thursdays, 3:30 PM - 5:00 PM" />
+          </div>
+          <div class="form-group">
+            <label for="admin-max-participants">Maximum Participants:</label>
+            <input type="number" id="admin-max-participants" required min="1" placeholder="20" />
+          </div>
+          <div class="button-row">
+            <button type="submit" id="admin-save-button">Create Activity</button>
+            <button type="button" id="admin-delete-button" class="secondary hidden">Delete Activity</button>
+          </div>
+        </form>
+        <div id="admin-message" class="hidden"></div>
+      </section>
     </main>
 
     <footer>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -9,7 +9,7 @@ body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
   color: #333;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
   padding: 20px;
   background-color: #f5f5f5;
@@ -29,15 +29,15 @@ header h1 {
 }
 
 main {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: 30px;
-  justify-content: center;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
 }
 
 @media (min-width: 768px) {
   main {
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: minmax(380px, 2fr) minmax(320px, 1fr);
   }
 }
 
@@ -47,7 +47,17 @@ section {
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   width: 100%;
-  max-width: 500px;
+}
+
+#activities-container {
+  grid-column: 1 / -1;
+}
+
+@media (min-width: 1100px) {
+  #activities-container {
+    grid-column: auto;
+    grid-row: span 2;
+  }
 }
 
 section h3 {
@@ -68,6 +78,14 @@ section h3 {
 .activity-card h4 {
   margin-bottom: 10px;
   color: #0066cc;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
 }
 
 .activity-card p {
@@ -111,23 +129,59 @@ section h3 {
 }
 
 .delete-btn {
-  background: none;
-  border: none;
+  background-color: #ffebee;
+  border: 1px solid #ef9a9a;
   color: #c62828;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 5px;
+  font-size: 13px;
+  padding: 4px 8px;
   transition: all 0.2s;
   border-radius: 3px;
 }
 
 .delete-btn:hover {
-  background-color: #ffebee;
+  background-color: #ffcdd2;
+}
+
+.edit-btn,
+.secondary {
+  background-color: #e8eaf6;
+  color: #1a237e;
+  border: 1px solid #c5cae9;
+}
+
+.edit-btn:hover,
+.secondary:hover {
+  background-color: #c5cae9;
 }
 
 .participants-section p {
   color: #777;
   font-style: italic;
+}
+
+.section-intro {
+  margin-bottom: 16px;
+  color: #555;
+}
+
+.admin-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.admin-toolbar .form-group {
+  flex: 1 1 240px;
+  margin-bottom: 0;
+}
+
+.button-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .form-group {
@@ -141,12 +195,18 @@ section h3 {
 }
 
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
   width: 100%;
   padding: 10px;
   border: 1px solid #ddd;
   border-radius: 4px;
   font-size: 16px;
+}
+
+.form-group textarea {
+  min-height: 110px;
+  resize: vertical;
 }
 
 button {


### PR DESCRIPTION
## Summary
- add backend activity CRUD endpoints (`POST /activities`, `PUT /activities/{activity_name}`, `DELETE /activities/{activity_name}`)
- add payload validation and signup capacity guard
- add admin management UI to create, edit, and delete activities
- wire frontend logic to keep signup and admin views in sync

## Files Updated
- `src/app.py`
- `src/static/index.html`
- `src/static/app.js`
- `src/static/styles.css`

Closes #150