### PR TITLE
Add GitHub.copilot-chat to devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
     "vscode": {
       "extensions": [
         "GitHub.copilot",
+        "GitHub.copilot-chat",
         "ms-python.python",
         "ms-python.debugpy",
         "dbaeumer.vscode-eslint"


### PR DESCRIPTION
Adds GitHub.copilot-chat extension to the VS Code extensions in the devcontainer configuration.