### PR TITLE
Add authentication and RBAC for activity enrollment

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,26 @@
+{
+    "inputs": [
+        {
+            "type": "promptString",
+            "id": "github_token",
+            "description": "GitHub Personal Access Token",
+            "password": true
+        }
+    ],
+    "servers": {
+        "github": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "-e",
+                "GITHUB_PERSONAL_ACCESS_TOKEN",
+                "ghcr.io/github/github-mcp-server"
+            ],
+            "env": {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+            }
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 fastapi
 uvicorn
+pydantic
+passlib[bcrypt]
+python-multipart
+PyJWT

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,16 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, status
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from auth import (
+    get_current_user, require_organizer, require_admin,
+    LoginRequest, TokenResponse, TokenData, Role,
+    verify_password, create_access_token, users_db
+)
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -83,14 +88,59 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
-@app.get("/activities")
+@app.post("/auth/login", response_model=TokenResponse)
+def login(request: LoginRequest):
+    """
+    Authenticate with email and password, receive JWT token.
+    
+    Sample users for testing:
+    - email: student@mergington.edu, password: student_password (role: student)
+    - email: organizer@mergington.edu, password: organizer_password (role: organizer)
+    - email: admin@mergington.edu, password: admin_password (role: admin)
+    """
+    # Check if user exists
+    if request.email not in users_db:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password"
+        )
+    
+    user = users_db[request.email]
+    
+    # Verify password
+    if not verify_password(request.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password"
+        )
+    
+    # Create token
+    access_token = create_access_token(email=user.email, role=user.role)
+    
+    return TokenResponse(
+        access_token=access_token,
+        token_type="bearer",
+        role=user.role.value
+    )
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    current_user: TokenData = Depends(get_current_user)
+):
+    """Sign up a student for an activity (requires authentication)"""
+    
+    # Authorization: User can only sign up themselves, unless they're organizer/admin
+    if current_user.email != email and current_user.role not in [Role.ORGANIZER, Role.ADMIN]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only manage your own enrollments"
+        )
+    
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +161,20 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    current_user: TokenData = Depends(get_current_user)
+):
+    """Unregister a student from an activity (requires authentication)"""
+    
+    # Authorization: User can only unregister themselves, unless they're organizer/admin
+    if current_user.email != email and current_user.role not in [Role.ORGANIZER, Role.ADMIN]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only manage your own enrollments"
+        )
+    
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,174 @@
+"""
+Authentication and authorization utilities for the Mergington High School API.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+from enum import Enum
+from pydantic import BaseModel
+import jwt
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthCredentials
+
+# Configuration
+SECRET_KEY = "your-secret-key-change-this-in-production"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+# Password hashing
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+security = HTTPBearer()
+
+
+class Role(str, Enum):
+    """User roles in the system"""
+    STUDENT = "student"
+    ORGANIZER = "organizer"
+    ADMIN = "admin"
+
+
+class TokenData(BaseModel):
+    """JWT token payload"""
+    email: str
+    role: Role
+
+
+class User(BaseModel):
+    """User model"""
+    email: str
+    role: Role
+    hashed_password: str
+
+
+class LoginRequest(BaseModel):
+    """Login request model"""
+    email: str
+    password: str
+
+
+class TokenResponse(BaseModel):
+    """Token response after login"""
+    access_token: str
+    token_type: str
+    role: str
+
+
+# In-memory user database (replace with real database later)
+users_db: dict[str, User] = {
+    "student@mergington.edu": User(
+        email="student@mergington.edu",
+        role=Role.STUDENT,
+        hashed_password=pwd_context.hash("student_password")
+    ),
+    "organizer@mergington.edu": User(
+        email="organizer@mergington.edu",
+        role=Role.ORGANIZER,
+        hashed_password=pwd_context.hash("organizer_password")
+    ),
+    "admin@mergington.edu": User(
+        email="admin@mergington.edu",
+        role=Role.ADMIN,
+        hashed_password=pwd_context.hash("admin_password")
+    ),
+    "emma@mergington.edu": User(
+        email="emma@mergington.edu",
+        role=Role.STUDENT,
+        hashed_password=pwd_context.hash("emma_password")
+    ),
+    "john@mergington.edu": User(
+        email="john@mergington.edu",
+        role=Role.STUDENT,
+        hashed_password=pwd_context.hash("john_password")
+    ),
+}
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a password against its hash"""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(email: str, role: Role, expires_delta: Optional[timedelta] = None) -> str:
+    """Create a JWT access token"""
+    if expires_delta is None:
+        expires_delta = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    
+    expire = datetime.utcnow() + expires_delta
+    payload = {
+        "email": email,
+        "role": role.value,
+        "exp": expire,
+        "iat": datetime.utcnow()
+    }
+    
+    encoded_jwt = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def decode_token(token: str) -> TokenData:
+    """Decode a JWT token and return token data"""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        email: str = payload.get("email")
+        role: str = payload.get("role")
+        
+        if email is None or role is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        
+        return TokenData(email=email, role=Role(role))
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+async def get_current_user(credentials: HTTPAuthCredentials = Depends(security)) -> TokenData:
+    """
+    Dependency to get the current authenticated user from the token.
+    Returns 401 if not authenticated.
+    """
+    token = credentials.credentials
+    return decode_token(token)
+
+
+async def require_student(current_user: TokenData = Depends(get_current_user)) -> TokenData:
+    """Require the user to be a student or higher role"""
+    if current_user.role not in [Role.STUDENT, Role.ORGANIZER, Role.ADMIN]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Student access required"
+        )
+    return current_user
+
+
+async def require_organizer(current_user: TokenData = Depends(get_current_user)) -> TokenData:
+    """Require the user to be an organizer or admin"""
+    if current_user.role not in [Role.ORGANIZER, Role.ADMIN]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Organizer access required"
+        )
+    return current_user
+
+
+async def require_admin(current_user: TokenData = Depends(get_current_user)) -> TokenData:
+    """Require the user to have admin role"""
+    if current_user.role != Role.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required"
+        )
+    return current_user


### PR DESCRIPTION
## Summary
Implement authentication and role-based authorization for the activity enrollment API.

## What Changed
- Added JWT-based authentication utilities and role model (`student`, `organizer`, `admin`)
- Added login endpoint: `POST /auth/login`
- Protected enrollment endpoints with authentication checks
- Enforced authorization so students can only manage their own enrollments
- Allowed organizer/admin roles to manage enrollments for other users
- Added password hashing and auth dependencies to project requirements

## Acceptance Criteria Coverage
- Protected routes return `401` when unauthenticated
- Role/ownership violations return `403`
- Users can only manage their own enrollments unless organizer/admin
- Authentication flow and sample credentials are documented in endpoint docstring

Closes #227