### PR TITLE
Add MCP config and teacher-only admin mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ __pycache__
 
 # Env files
 .env
+
+# Local teacher credential file (do not commit real credentials)
+src/teachers.json

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}

--- a/src/app.py
+++ b/src/app.py
@@ -9,15 +9,41 @@ from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
+import uuid
 from pathlib import Path
+from pydantic import BaseModel
+from fastapi import Header
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+
+class AdminLoginRequest(BaseModel):
+    username: str
+    password: str
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+def load_teacher_credentials() -> dict[str, str]:
+    """Load teacher credentials from a JSON file in the project directory."""
+    teachers_file = current_dir / "teachers.json"
+
+    if not teachers_file.exists():
+        return {}
+
+    with open(teachers_file, "r", encoding="utf-8") as fp:
+        payload = json.load(fp)
+
+    return payload.get("teachers", {})
+
+
+teacher_credentials = load_teacher_credentials()
+active_admin_tokens: dict[str, str] = {}
 
 # In-memory activity database
 activities = {
@@ -88,9 +114,41 @@ def get_activities():
     return activities
 
 
+@app.post("/admin/login")
+def admin_login(request: AdminLoginRequest):
+    """Authenticate a teacher and return a temporary admin token."""
+    valid_password = teacher_credentials.get(request.username)
+
+    if valid_password is None or valid_password != request.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = str(uuid.uuid4())
+    active_admin_tokens[token] = request.username
+
+    return {
+        "message": "Login successful",
+        "token": token,
+        "username": request.username
+    }
+
+
+def verify_admin_token(token: str | None):
+    if token is None or token not in active_admin_tokens:
+        raise HTTPException(
+            status_code=403,
+            detail="Admin privileges required"
+        )
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token")
+):
     """Sign up a student for an activity"""
+    verify_admin_token(x_admin_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +169,14 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token")
+):
     """Unregister a student from an activity"""
+    verify_admin_token(x_admin_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,9 @@ from fastapi.responses import RedirectResponse
 import os
 import json
 import uuid
+import hmac
+import hashlib
+import time
 from pathlib import Path
 from pydantic import BaseModel
 from fastapi import Header
@@ -28,22 +31,62 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
+ADMIN_TOKEN_TTL_SECONDS = int(os.getenv("ADMIN_TOKEN_TTL_SECONDS", "3600"))
+
 
 def load_teacher_credentials() -> dict[str, str]:
-    """Load teacher credentials from a JSON file in the project directory."""
+    """Load teacher credentials from env JSON or a local JSON file."""
+    env_json = os.getenv("TEACHER_CREDENTIALS_JSON")
+
+    if env_json:
+        try:
+            payload = json.loads(env_json)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                "Invalid TEACHER_CREDENTIALS_JSON value: expected valid JSON"
+            ) from exc
+
+        return payload.get("teachers", {})
+
     teachers_file = current_dir / "teachers.json"
 
     if not teachers_file.exists():
         return {}
 
-    with open(teachers_file, "r", encoding="utf-8") as fp:
-        payload = json.load(fp)
+    try:
+        with open(teachers_file, "r", encoding="utf-8") as fp:
+            payload = json.load(fp)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"Failed to load teacher credentials from {teachers_file}"
+        ) from exc
 
     return payload.get("teachers", {})
 
 
+def verify_password(stored_password: str, provided_password: str) -> bool:
+    """Support either plaintext (demo) or sha256$<hex> credential format."""
+    if stored_password.startswith("sha256$"):
+        expected_hash = stored_password.split("$", 1)[1]
+        actual_hash = hashlib.sha256(provided_password.encode("utf-8")).hexdigest()
+        return hmac.compare_digest(expected_hash, actual_hash)
+
+    return hmac.compare_digest(stored_password, provided_password)
+
+
+def cleanup_expired_tokens() -> None:
+    now = time.time()
+    expired_tokens = [
+        token for token, expires_at in active_admin_tokens.items()
+        if expires_at <= now
+    ]
+
+    for token in expired_tokens:
+        del active_admin_tokens[token]
+
+
 teacher_credentials = load_teacher_credentials()
-active_admin_tokens: dict[str, str] = {}
+active_admin_tokens: dict[str, float] = {}
 
 # In-memory activity database
 activities = {
@@ -117,26 +160,38 @@ def get_activities():
 @app.post("/admin/login")
 def admin_login(request: AdminLoginRequest):
     """Authenticate a teacher and return a temporary admin token."""
+    cleanup_expired_tokens()
     valid_password = teacher_credentials.get(request.username)
 
-    if valid_password is None or valid_password != request.password:
+    if valid_password is None or not verify_password(valid_password, request.password):
         raise HTTPException(status_code=401, detail="Invalid username or password")
 
     token = str(uuid.uuid4())
-    active_admin_tokens[token] = request.username
+    expires_at = time.time() + ADMIN_TOKEN_TTL_SECONDS
+    active_admin_tokens[token] = expires_at
 
     return {
         "message": "Login successful",
         "token": token,
-        "username": request.username
+        "username": request.username,
+        "expires_in_seconds": ADMIN_TOKEN_TTL_SECONDS
     }
 
 
 def verify_admin_token(token: str | None):
+    cleanup_expired_tokens()
+
     if token is None or token not in active_admin_tokens:
         raise HTTPException(
             status_code=403,
             detail="Admin privileges required"
+        )
+
+    if active_admin_tokens[token] <= time.time():
+        del active_admin_tokens[token]
+        raise HTTPException(
+            status_code=403,
+            detail="Admin token expired"
         )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ import json
 import uuid
 import hmac
 import hashlib
+import binascii
 import time
 from pathlib import Path
 from pydantic import BaseModel
@@ -32,6 +33,30 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
 ADMIN_TOKEN_TTL_SECONDS = int(os.getenv("ADMIN_TOKEN_TTL_SECONDS", "3600"))
+ALLOW_PLAINTEXT_CREDENTIALS = (
+    os.getenv("ALLOW_PLAINTEXT_CREDENTIALS", "false").lower() == "true"
+)
+
+
+def parse_teacher_credentials_payload(payload: object, source: str) -> dict[str, str]:
+    """Validate credentials payload shape and return a normalized mapping."""
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Invalid {source}: expected top-level JSON object")
+
+    teachers = payload.get("teachers", {})
+    if not isinstance(teachers, dict):
+        raise RuntimeError(f"Invalid {source}: 'teachers' must be a JSON object")
+
+    invalid_entries = [
+        key for key, value in teachers.items()
+        if not isinstance(key, str) or not isinstance(value, str)
+    ]
+    if invalid_entries:
+        raise RuntimeError(
+            f"Invalid {source}: teacher usernames/passwords must be strings"
+        )
+
+    return teachers
 
 
 def load_teacher_credentials() -> dict[str, str]:
@@ -46,7 +71,7 @@ def load_teacher_credentials() -> dict[str, str]:
                 "Invalid TEACHER_CREDENTIALS_JSON value: expected valid JSON"
             ) from exc
 
-        return payload.get("teachers", {})
+        return parse_teacher_credentials_payload(payload, "TEACHER_CREDENTIALS_JSON")
 
     teachers_file = current_dir / "teachers.json"
 
@@ -61,15 +86,43 @@ def load_teacher_credentials() -> dict[str, str]:
             f"Failed to load teacher credentials from {teachers_file}"
         ) from exc
 
-    return payload.get("teachers", {})
+    return parse_teacher_credentials_payload(payload, str(teachers_file))
+
+
+def verify_pbkdf2_sha256_password(stored_password: str, provided_password: str) -> bool:
+    parts = stored_password.split("$", 3)
+    if len(parts) != 4:
+        return False
+
+    _, iterations_text, salt_hex, expected_hash_hex = parts
+    try:
+        iterations = int(iterations_text)
+        salt = bytes.fromhex(salt_hex)
+        expected_hash = bytes.fromhex(expected_hash_hex)
+    except (ValueError, binascii.Error):
+        return False
+
+    actual_hash = hashlib.pbkdf2_hmac(
+        "sha256",
+        provided_password.encode("utf-8"),
+        salt,
+        iterations
+    )
+    return hmac.compare_digest(expected_hash, actual_hash)
 
 
 def verify_password(stored_password: str, provided_password: str) -> bool:
-    """Support either plaintext (demo) or sha256$<hex> credential format."""
+    """Verify password against pbkdf2/sha256 formats, optionally plaintext for demos."""
+    if stored_password.startswith("pbkdf2_sha256$"):
+        return verify_pbkdf2_sha256_password(stored_password, provided_password)
+
     if stored_password.startswith("sha256$"):
         expected_hash = stored_password.split("$", 1)[1]
         actual_hash = hashlib.sha256(provided_password.encode("utf-8")).hexdigest()
         return hmac.compare_digest(expected_hash, actual_hash)
+
+    if not ALLOW_PLAINTEXT_CREDENTIALS:
+        return False
 
     return hmac.compare_digest(stored_password, provided_password)
 
@@ -181,14 +234,21 @@ def admin_login(request: AdminLoginRequest):
 def verify_admin_token(token: str | None):
     cleanup_expired_tokens()
 
-    if token is None or token not in active_admin_tokens:
+    if token is None:
         raise HTTPException(
             status_code=403,
             detail="Admin privileges required"
         )
 
-    if active_admin_tokens[token] <= time.time():
-        del active_admin_tokens[token]
+    expires_at = active_admin_tokens.get(token)
+    if expires_at is None:
+        raise HTTPException(
+            status_code=403,
+            detail="Admin privileges required"
+        )
+
+    if expires_at <= time.time():
+        active_admin_tokens.pop(token, None)
         raise HTTPException(
             status_code=403,
             detail="Admin token expired"

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -43,7 +43,7 @@ document.addEventListener("DOMContentLoaded", () => {
       adminStatus.textContent = `Logged in as ${adminUsername}. You can register and unregister students.`;
       adminStatus.className = "message success";
       userMenuBtn.textContent = "✅";
-      userMenuBtn.setAttribute("aria-label", "Admin logged in");
+      userMenuBtn.setAttribute("aria-label", "Open teacher menu");
       userMenuBtn.title = "Teacher logged in";
     } else {
       adminStatus.textContent = "Students can view activity rosters. Teachers must log in to register or unregister students.";

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -11,14 +11,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
   let adminToken = null;
   let adminUsername = null;
+  let messageTimeoutId = null;
 
   function showMessage(text, type) {
     messageDiv.textContent = text;
-    messageDiv.className = type;
+    messageDiv.className = `message ${type}`;
     messageDiv.classList.remove("hidden");
 
-    setTimeout(() => {
+    if (messageTimeoutId !== null) {
+      clearTimeout(messageTimeoutId);
+    }
+
+    messageTimeoutId = setTimeout(() => {
       messageDiv.classList.add("hidden");
+      messageTimeoutId = null;
     }, 5000);
   }
 
@@ -33,12 +39,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (isAdmin) {
       adminStatus.textContent = `Logged in as ${adminUsername}. You can register and unregister students.`;
-      adminStatus.className = "success";
+      adminStatus.className = "message success";
       userMenuBtn.textContent = "✅";
       userMenuBtn.title = "Teacher logged in";
     } else {
       adminStatus.textContent = "Students can view activity rosters. Teachers must log in to register or unregister students.";
-      adminStatus.className = "info";
+      adminStatus.className = "message info";
       userMenuBtn.textContent = "👤";
       userMenuBtn.title = "Open teacher login";
     }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -8,10 +8,12 @@ document.addEventListener("DOMContentLoaded", () => {
   const closeModalBtn = document.getElementById("close-modal-btn");
   const adminLoginForm = document.getElementById("admin-login-form");
   const adminStatus = document.getElementById("admin-status");
+  const adminUsernameInput = document.getElementById("admin-username");
 
   let adminToken = null;
   let adminUsername = null;
   let messageTimeoutId = null;
+  let lastFocusedElement = null;
 
   function showMessage(text, type) {
     messageDiv.textContent = text;
@@ -41,12 +43,27 @@ document.addEventListener("DOMContentLoaded", () => {
       adminStatus.textContent = `Logged in as ${adminUsername}. You can register and unregister students.`;
       adminStatus.className = "message success";
       userMenuBtn.textContent = "✅";
+      userMenuBtn.setAttribute("aria-label", "Admin logged in");
       userMenuBtn.title = "Teacher logged in";
     } else {
       adminStatus.textContent = "Students can view activity rosters. Teachers must log in to register or unregister students.";
       adminStatus.className = "message info";
       userMenuBtn.textContent = "👤";
+      userMenuBtn.setAttribute("aria-label", "Open admin login");
       userMenuBtn.title = "Open teacher login";
+    }
+  }
+
+  function openAdminModal() {
+    lastFocusedElement = document.activeElement;
+    adminModal.classList.remove("hidden");
+    adminUsernameInput.focus();
+  }
+
+  function closeAdminModal() {
+    adminModal.classList.add("hidden");
+    if (lastFocusedElement instanceof HTMLElement) {
+      lastFocusedElement.focus();
     }
   }
 
@@ -82,7 +99,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     (email) =>
                       `<li><span class="participant-email">${email}</span>${
                         isAdmin
-                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          ? `<button class="delete-btn" type="button" aria-label="Unregister ${email} from ${name}" data-activity="${name}" data-email="${email}">❌</button>`
                           : ""
                       }</li>`
                   )
@@ -198,12 +215,48 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  userMenuBtn.addEventListener("click", () => {
-    adminModal.classList.remove("hidden");
+  userMenuBtn.addEventListener("click", openAdminModal);
+
+  closeModalBtn.addEventListener("click", closeAdminModal);
+
+  adminModal.addEventListener("click", (event) => {
+    if (event.target === adminModal) {
+      closeAdminModal();
+    }
   });
 
-  closeModalBtn.addEventListener("click", () => {
-    adminModal.classList.add("hidden");
+  document.addEventListener("keydown", (event) => {
+    if (adminModal.classList.contains("hidden")) {
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeAdminModal();
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusableElements = adminModal.querySelectorAll(
+      "button, input, select, textarea, [href], [tabindex]:not([tabindex='-1'])"
+    );
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
   });
 
   adminLoginForm.addEventListener("submit", async (event) => {
@@ -231,7 +284,7 @@ document.addEventListener("DOMContentLoaded", () => {
       adminToken = result.token;
       adminUsername = result.username;
       adminLoginForm.reset();
-      adminModal.classList.add("hidden");
+      closeAdminModal();
       updateAdminUI();
       fetchActivities();
       showMessage(`Welcome ${adminUsername}. Admin mode enabled.`, "success");

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,46 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const adminModal = document.getElementById("admin-modal");
+  const closeModalBtn = document.getElementById("close-modal-btn");
+  const adminLoginForm = document.getElementById("admin-login-form");
+  const adminStatus = document.getElementById("admin-status");
+
+  let adminToken = null;
+  let adminUsername = null;
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAdminUI() {
+    const isAdmin = Boolean(adminToken);
+    const submitButton = signupForm.querySelector("button[type='submit']");
+
+    signupForm.querySelectorAll("input, select").forEach((element) => {
+      element.disabled = !isAdmin;
+    });
+    submitButton.disabled = !isAdmin;
+
+    if (isAdmin) {
+      adminStatus.textContent = `Logged in as ${adminUsername}. You can register and unregister students.`;
+      adminStatus.className = "success";
+      userMenuBtn.textContent = "✅";
+      userMenuBtn.title = "Teacher logged in";
+    } else {
+      adminStatus.textContent = "Students can view activity rosters. Teachers must log in to register or unregister students.";
+      adminStatus.className = "info";
+      userMenuBtn.textContent = "👤";
+      userMenuBtn.title = "Open teacher login";
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +52,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
+
+      const isAdmin = Boolean(adminToken);
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +74,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isAdmin
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -80,32 +128,24 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "X-Admin-Token": adminToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +153,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!adminToken) {
+      showMessage("Teachers must log in before registering students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +169,73 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            "X-Admin-Token": adminToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuBtn.addEventListener("click", () => {
+    adminModal.classList.remove("hidden");
+  });
+
+  closeModalBtn.addEventListener("click", () => {
+    adminModal.classList.add("hidden");
+  });
+
+  adminLoginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("admin-username").value;
+    const password = document.getElementById("admin-password").value;
+
+    try {
+      const response = await fetch("/admin/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Failed to log in", "error");
+        return;
+      }
+
+      adminToken = result.token;
+      adminUsername = result.username;
+      adminLoginForm.reset();
+      adminModal.classList.add("hidden");
+      updateAdminUI();
+      fetchActivities();
+      showMessage(`Welcome ${adminUsername}. Admin mode enabled.`, "success");
+    } catch (error) {
+      showMessage("Failed to log in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
   // Initialize app
+  updateAdminUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,9 +8,32 @@
   </head>
   <body>
     <header>
+      <div id="admin-controls">
+        <button id="user-menu-btn" type="button" aria-label="Open admin login">👤</button>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
+
+    <div id="admin-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="admin-login-title">
+      <div class="modal-content">
+        <h3 id="admin-login-title">Teacher Login</h3>
+        <form id="admin-login-form">
+          <div class="form-group">
+            <label for="admin-username">Username:</label>
+            <input type="text" id="admin-username" required placeholder="teacher username" />
+          </div>
+          <div class="form-group">
+            <label for="admin-password">Password:</label>
+            <input type="password" id="admin-password" required placeholder="password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button id="close-modal-btn" type="button" class="secondary-btn">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -23,6 +46,7 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="admin-status" class="info">Students can view activity rosters. Teachers must log in to register or unregister students.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -46,7 +46,7 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
-        <p id="admin-status" class="info">Students can view activity rosters. Teachers must log in to register or unregister students.</p>
+        <p id="admin-status" class="message info">Students can view activity rosters. Teachers must log in to register or unregister students.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -61,7 +61,7 @@
           </div>
           <button type="submit">Sign Up</button>
         </form>
-        <div id="message" class="hidden"></div>
+        <div id="message" class="message hidden"></div>
       </section>
     </main>
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,27 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+#admin-controls {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+}
+
+#user-menu-btn {
+  background-color: #ffffff;
+  color: #1a237e;
+  border: none;
+  border-radius: 999px;
+  width: 40px;
+  height: 40px;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+#user-menu-btn:hover {
+  background-color: #e8eaf6;
 }
 
 main {
@@ -164,6 +186,11 @@ button:hover {
   background-color: #3949ab;
 }
 
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -190,6 +217,38 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.modal-content {
+  width: min(90vw, 420px);
+  background-color: white;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.secondary-btn {
+  background-color: #eceff1;
+  color: #263238;
+}
+
+.secondary-btn:hover {
+  background-color: #dfe4e8;
 }
 
 footer {

--- a/src/teachers.example.json
+++ b/src/teachers.example.json
@@ -1,0 +1,5 @@
+{
+  "teachers": {
+    "teacher1": "sha256$4fbeca66ddd051bef15a7bc104465223a19fdbae7763ea43d1aae745e54d46cd"
+  }
+}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": {
+    "teacher1": "mergington123",
+    "principal": "green-lime-pride"
+  }
+}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,6 +1,0 @@
-{
-  "teachers": {
-    "teacher1": "mergington123",
-    "principal": "green-lime-pride"
-  }
-}


### PR DESCRIPTION
## Summary
- add GitHub MCP server configuration in VS Code
- implement Admin Mode with teacher login modal and API authentication token
- restrict register/unregister actions to authenticated teachers

## Validation
- python3 -m py_compile src/app.py
- node --check src/static/app.js
- smoke tested /activities and /admin/login
